### PR TITLE
Feat: add accessibility labels and improve settings display

### DIFF
--- a/buschecker/ContentView.swift
+++ b/buschecker/ContentView.swift
@@ -309,6 +309,7 @@ struct ContentView: View {
                         .background(.ultraThinMaterial, in: Circle())
                 }
                 .buttonStyle(.plain)
+                .accessibilityLabel("Settings")
                 
                 // Pinned stops button
                 Button {
@@ -317,7 +318,7 @@ struct ContentView: View {
                     HStack(spacing: 6) {
                         Image(systemName: "pin.fill")
                             .font(.system(size: 14, weight: .medium))
-                        
+
                         if !pinnedStops.isEmpty {
                             Text("\(pinnedStops.count)")
                                 .font(.system(size: 12, weight: .bold))
@@ -329,6 +330,7 @@ struct ContentView: View {
                     .background(.ultraThinMaterial, in: Capsule())
                 }
                 .buttonStyle(.plain)
+                .accessibilityLabel("Pinned stops, \(pinnedStops.count) saved")
             }
             .padding(.leading, 12)
             .padding(.bottom, 8)
@@ -354,6 +356,7 @@ struct ContentView: View {
                         .background(.ultraThinMaterial, in: Circle())
                 }
                 .buttonStyle(.plain)
+                .accessibilityLabel("Center on my location")
                 
                 // Radius control (for nearby filtering)
                 Menu {
@@ -376,6 +379,7 @@ struct ContentView: View {
                         .background(.ultraThinMaterial, in: Capsule())
                 }
                 .buttonStyle(.plain)
+                .accessibilityLabel("Search radius \(Int(locationManager.searchRadius)) meters")
             }
             .padding(.trailing, 12)
             .padding(.bottom, 8)
@@ -424,11 +428,12 @@ struct BusStopMarker: View {
                 .fill(.white)
                 .frame(width: 32, height: 32)
                 .shadow(color: .black.opacity(0.15), radius: 3, y: 2)
-            
+
             Image(systemName: "bus.fill")
                 .font(.system(size: 16, weight: .semibold))
                 .foregroundStyle(.blue)
         }
+        .accessibilityLabel("Bus stop")
     }
 }
 
@@ -436,18 +441,19 @@ struct BusStopMarker: View {
 
 struct PinnedStopMarker: View {
     var color: Color = .orange
-    
+
     var body: some View {
         ZStack {
             Circle()
                 .fill(color)
                 .frame(width: 36, height: 36)
                 .shadow(color: color.opacity(0.4), radius: 4, y: 2)
-            
+
             Image(systemName: "bus.fill")
                 .font(.system(size: 16, weight: .semibold))
                 .foregroundColor(.white)
         }
+        .accessibilityLabel("Pinned bus stop")
     }
 }
 

--- a/buschecker/PrivacyInfo.xcprivacy
+++ b/buschecker/PrivacyInfo.xcprivacy
@@ -18,7 +18,16 @@
         </dict>
     </array>
     <key>NSPrivacyAccessedAPITypes</key>
-    <array/>
+    <array>
+        <dict>
+            <key>NSPrivacyAccessedAPIType</key>
+            <string>NSPrivacyAccessedAPICategoryUserDefaults</string>
+            <key>NSPrivacyAccessedAPITypeReasons</key>
+            <array>
+                <string>CA92.1</string>
+            </array>
+        </dict>
+    </array>
     <key>NSPrivacyTracking</key>
     <false/>
     <key>NSPrivacyTrackingDomains</key>

--- a/buschecker/Views/SettingsView.swift
+++ b/buschecker/Views/SettingsView.swift
@@ -130,10 +130,17 @@ struct SettingsView: View {
                     HStack {
                         Text("Version")
                         Spacer()
-                        Text("1.0.0")
+                        Text(Bundle.main.infoDictionary?["CFBundleShortVersionString"] as? String ?? "1.0")
                             .foregroundStyle(.secondary)
                     }
-                    
+
+                    HStack {
+                        Text("Build")
+                        Spacer()
+                        Text(Bundle.main.infoDictionary?["CFBundleVersion"] as? String ?? "1")
+                            .foregroundStyle(.secondary)
+                    }
+
                     HStack {
                         Text("Data Source")
                         Spacer()


### PR DESCRIPTION
## Summary

- Add `accessibilityLabel` modifiers to interactive buttons (Settings, Pinned stops, Location, Radius) for VoiceOver support
- Add accessibility labels to `BusStopMarker` and `PinnedStopMarker` views
- Update `PrivacyInfo.xcprivacy` to declare UserDefaults API usage (CA92.1) for App Store compliance
- Display dynamic version and build number in Settings instead of hardcoded "1.0.0"

## Test plan

- [ ] Enable VoiceOver on iOS device/simulator and verify all buttons announce their labels correctly
- [ ] Verify Settings view displays the correct app version and build number
- [ ] Confirm app builds and runs without warnings

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Enhanced accessibility support with improved screen reader labels for all interactive controls, buttons, and map markers.

* **Bug Fixes**
  * App now displays the correct version and build numbers from the app bundle instead of hardcoded placeholder values.

* **Chores**
  * Updated privacy tracking metadata for user preferences access.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->